### PR TITLE
Rejecting with the stream error to reveal cause

### DIFF
--- a/index.js
+++ b/index.js
@@ -184,7 +184,7 @@ module.exports = class RPC extends Duplex {
 
   _destroy (cb) {
     for (const req of this.requests) {
-      if (req) req.reject(new Error('RPC stream destroyed'))
+      if (req) req.reject(this._readableState.error || this._writableState.error || new Error('RPC stream destroyed'))
     }
     this.requests = []
     cb(null)


### PR DESCRIPTION
I was getting a pretty non-descriptive error like: `Error: RPC stream destroyed`. With this proposed changed, I understood what error happened: `Error: Websocket closed[1006] (reason="", clean=false)`